### PR TITLE
Add multi-arch build workflows and update CI configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
       - "examples/fl-demo/local-data-store"
       - "examples/fl-demo/model-registry"
       - "examples/fl-demo"
-      -
 
     schedule:
       interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Build
+        shell: bash
         run: |
           mkdir -p dist
           ext=""
@@ -91,6 +92,7 @@ jobs:
 
       - name: Install cross-compilation toolchains
         if: matrix.runner == 'ubuntu-latest' && matrix.goarch != 'amd64'
+        shell: bash
         run: |
           sudo apt-get update
           case "${{ matrix.goos }}-${{ matrix.goarch }}" in
@@ -99,6 +101,7 @@ jobs:
           esac
 
       - name: Build
+        shell: bash
         env:
           ext: ""
           target: ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,6 @@ jobs:
           - { goos: darwin, goarch: arm64, runner: macos-latest }
           - { goos: windows, goarch: amd64, runner: windows-latest }
           - { goos: windows, goarch: arm64, runner: windows-latest }
-          - { goos: freebsd, goarch: amd64, runner: ubuntu-latest }
-          - { goos: freebsd, goarch: arm64, runner: ubuntu-latest }
-          - { goos: netbsd, goarch: amd64, runner: ubuntu-latest }
-          - { goos: openbsd, goarch: amd64, runner: ubuntu-latest }
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,79 @@ jobs:
           path: dist/
           retention-days: 7
 
+  proplet:
+    name: proplet-${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: linux, goarch: riscv64 }
+          - { goos: darwin, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
+          - { goos: windows, goarch: amd64 }
+          - { goos: windows, goarch: arm64 }
+          - { goos: freebsd, goarch: amd64 }
+          - { goos: freebsd, goarch: arm64 }
+          - { goos: freebsd, goarch: riscv64 }
+          - { goos: netbsd, goarch: amd64 }
+          - { goos: netbsd, goarch: arm64 }
+          - { goos: openbsd, goarch: amd64 }
+          - { goos: openbsd, goarch: arm64 }
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        env:
+          ext: ""
+          target: ""
+        run: |
+          mkdir -p dist
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            ext=".exe"
+          fi
+          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
+            linux-amd64) target="x86_64-unknown-linux-gnu" ;;
+            linux-arm64) target="aarch64-unknown-linux-gnu" ;;
+            linux-riscv64) target="riscv64gc-unknown-linux-gnu" ;;
+            darwin-amd64) target="x86_64-apple-darwin" ;;
+            darwin-arm64) target="aarch64-apple-darwin" ;;
+            windows-amd64) target="x86_64-pc-windows-msvc" ;;
+            windows-arm64) target="aarch64-pc-windows-msvc" ;;
+            freebsd-amd64) target="x86_64-unknown-freebsd" ;;
+            freebsd-arm64) target="aarch64-unknown-freebsd" ;;
+            freebsd-riscv64) target="riscv64gc-unknown-freebsd" ;;
+            netbsd-amd64) target="x86_64-unknown-netbsd" ;;
+            netbsd-arm64) target="aarch64-unknown-netbsd" ;;
+            openbsd-amd64) target="x86_64-unknown-openbsd" ;;
+            openbsd-arm64) target="aarch64-unknown-openbsd" ;;
+          esac
+          if [ -n "$target" ]; then
+            rustup target add "$target"
+            cargo build --release --target "$target" -p proplet
+            mv target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+          else
+            cargo build --release -p proplet
+            mv target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: proplet-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
+          retention-days: 7
+
   release:
     name: GitHub Release
-    needs: build
+    needs: [build, proplet]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,18 +41,6 @@ jobs:
           - { goos: windows, goarch: arm64, service: cli }
           - { goos: windows, goarch: amd64, service: proxy }
           - { goos: windows, goarch: arm64, service: proxy }
-          - { goos: freebsd, goarch: amd64, service: manager }
-          - { goos: freebsd, goarch: arm64, service: manager }
-          - { goos: freebsd, goarch: amd64, service: cli }
-          - { goos: freebsd, goarch: arm64, service: cli }
-          - { goos: freebsd, goarch: amd64, service: proxy }
-          - { goos: freebsd, goarch: arm64, service: proxy }
-          - { goos: netbsd, goarch: amd64, service: manager }
-          - { goos: netbsd, goarch: amd64, service: cli }
-          - { goos: netbsd, goarch: amd64, service: proxy }
-          - { goos: openbsd, goarch: amd64, service: manager }
-          - { goos: openbsd, goarch: amd64, service: cli }
-          - { goos: openbsd, goarch: amd64, service: proxy }
 
     steps:
       - name: Checkout Code
@@ -108,7 +96,6 @@ jobs:
           case "${{ matrix.goos }}-${{ matrix.goarch }}" in
             linux-arm64) sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;;
             linux-riscv64) sudo apt-get install -y gcc-riscv64-linux-gnu libc6-dev-riscv64-cross ;;
-            freebsd-*) sudo apt-get install -y gcc-cross libclang-rt ;;
           esac
 
       - name: Build
@@ -128,10 +115,6 @@ jobs:
             darwin-arm64) target="aarch64-apple-darwin" ;;
             windows-amd64) target="x86_64-pc-windows-msvc" ;;
             windows-arm64) target="aarch64-pc-windows-msvc" ;;
-            freebsd-amd64) target="x86_64-unknown-freebsd" ;;
-            freebsd-arm64) target="aarch64-unknown-freebsd" ;;
-            netbsd-amd64) target="x86_64-unknown-netbsd" ;;
-            openbsd-amd64) target="x86_64-unknown-openbsd" ;;
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,16 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cross-compilation toolchains
+        if: matrix.goarch != 'amd64'
+        run: |
+          sudo apt-get update
+          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
+            linux-arm64) sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;;
+            linux-riscv64) sudo apt-get install -y gcc-riscv64-linux-gnu libc6-dev-riscv64-cross ;;
+            freebsd-*) sudo apt-get install -y gcc-cross libclang-rt ;;  # FreeBSD targets need cross compilers
+          esac
+
       - name: Build
         env:
           ext: ""
@@ -129,6 +139,8 @@ jobs:
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
             cd proplet && cargo build --release --target "$target"
             mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # linux — amd64, arm64, riscv64 all supported out-of-the-box
           - { goos: linux, goarch: amd64, service: manager }
           - { goos: linux, goarch: arm64, service: manager }
           - { goos: linux, goarch: riscv64, service: manager }
@@ -30,44 +29,30 @@ jobs:
           - { goos: linux, goarch: amd64, service: proxy }
           - { goos: linux, goarch: arm64, service: proxy }
           - { goos: linux, goarch: riscv64, service: proxy }
-          # darwin (macOS) — only amd64 and arm64 (Apple Silicon)
           - { goos: darwin, goarch: amd64, service: manager }
           - { goos: darwin, goarch: arm64, service: manager }
           - { goos: darwin, goarch: amd64, service: cli }
           - { goos: darwin, goarch: arm64, service: cli }
           - { goos: darwin, goarch: amd64, service: proxy }
           - { goos: darwin, goarch: arm64, service: proxy }
-          # windows — amd64 and arm64; riscv64 is not a valid windows target
           - { goos: windows, goarch: amd64, service: manager }
           - { goos: windows, goarch: arm64, service: manager }
           - { goos: windows, goarch: amd64, service: cli }
           - { goos: windows, goarch: arm64, service: cli }
           - { goos: windows, goarch: amd64, service: proxy }
           - { goos: windows, goarch: arm64, service: proxy }
-          # freebsd — riscv64 added in Go 1.20
           - { goos: freebsd, goarch: amd64, service: manager }
           - { goos: freebsd, goarch: arm64, service: manager }
-          - { goos: freebsd, goarch: riscv64, service: manager }
           - { goos: freebsd, goarch: amd64, service: cli }
           - { goos: freebsd, goarch: arm64, service: cli }
-          - { goos: freebsd, goarch: riscv64, service: cli }
           - { goos: freebsd, goarch: amd64, service: proxy }
           - { goos: freebsd, goarch: arm64, service: proxy }
-          - { goos: freebsd, goarch: riscv64, service: proxy }
-          # netbsd — no riscv64 port
           - { goos: netbsd, goarch: amd64, service: manager }
-          - { goos: netbsd, goarch: arm64, service: manager }
           - { goos: netbsd, goarch: amd64, service: cli }
-          - { goos: netbsd, goarch: arm64, service: cli }
           - { goos: netbsd, goarch: amd64, service: proxy }
-          - { goos: netbsd, goarch: arm64, service: proxy }
-          # openbsd — no riscv64 port
           - { goos: openbsd, goarch: amd64, service: manager }
-          - { goos: openbsd, goarch: arm64, service: manager }
           - { goos: openbsd, goarch: amd64, service: cli }
-          - { goos: openbsd, goarch: arm64, service: cli }
           - { goos: openbsd, goarch: amd64, service: proxy }
-          - { goos: openbsd, goarch: arm64, service: proxy }
 
     steps:
       - name: Checkout Code
@@ -110,11 +95,8 @@ jobs:
           - { goos: windows, goarch: arm64 }
           - { goos: freebsd, goarch: amd64 }
           - { goos: freebsd, goarch: arm64 }
-          - { goos: freebsd, goarch: riscv64 }
           - { goos: netbsd, goarch: amd64 }
-          - { goos: netbsd, goarch: arm64 }
           - { goos: openbsd, goarch: amd64 }
-          - { goos: openbsd, goarch: arm64 }
 
     steps:
       - name: Checkout Code
@@ -142,11 +124,8 @@ jobs:
             windows-arm64) target="aarch64-pc-windows-msvc" ;;
             freebsd-amd64) target="x86_64-unknown-freebsd" ;;
             freebsd-arm64) target="aarch64-unknown-freebsd" ;;
-            freebsd-riscv64) target="riscv64gc-unknown-freebsd" ;;
             netbsd-amd64) target="x86_64-unknown-netbsd" ;;
-            netbsd-arm64) target="aarch64-unknown-netbsd" ;;
             openbsd-amd64) target="x86_64-unknown-openbsd" ;;
-            openbsd-arm64) target="aarch64-unknown-openbsd" ;;
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,18 +29,6 @@ jobs:
           - { goos: linux, goarch: amd64, service: proxy }
           - { goos: linux, goarch: arm64, service: proxy }
           - { goos: linux, goarch: riscv64, service: proxy }
-          - { goos: darwin, goarch: amd64, service: manager }
-          - { goos: darwin, goarch: arm64, service: manager }
-          - { goos: darwin, goarch: amd64, service: cli }
-          - { goos: darwin, goarch: arm64, service: cli }
-          - { goos: darwin, goarch: amd64, service: proxy }
-          - { goos: darwin, goarch: arm64, service: proxy }
-          - { goos: windows, goarch: amd64, service: manager }
-          - { goos: windows, goarch: arm64, service: manager }
-          - { goos: windows, goarch: amd64, service: cli }
-          - { goos: windows, goarch: arm64, service: cli }
-          - { goos: windows, goarch: amd64, service: proxy }
-          - { goos: windows, goarch: arm64, service: proxy }
 
     steps:
       - name: Checkout Code
@@ -78,10 +66,6 @@ jobs:
           - { goos: linux, goarch: amd64, runner: ubuntu-latest }
           - { goos: linux, goarch: arm64, runner: ubuntu-latest }
           - { goos: linux, goarch: riscv64, runner: ubuntu-latest }
-          - { goos: darwin, goarch: amd64, runner: macos-latest }
-          - { goos: darwin, goarch: arm64, runner: macos-latest }
-          - { goos: windows, goarch: amd64, runner: windows-latest }
-          - { goos: windows, goarch: arm64, runner: windows-latest }
 
     steps:
       - name: Checkout Code
@@ -103,21 +87,13 @@ jobs:
       - name: Build
         shell: bash
         env:
-          ext: ""
           target: ""
         run: |
           mkdir -p dist
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            ext=".exe"
-          fi
           case "${{ matrix.goos }}-${{ matrix.goarch }}" in
             linux-amd64) target="x86_64-unknown-linux-gnu" ;;
             linux-arm64) target="aarch64-unknown-linux-gnu" ;;
             linux-riscv64) target="riscv64gc-unknown-linux-gnu" ;;
-            darwin-amd64) target="x86_64-apple-darwin" ;;
-            darwin-arm64) target="aarch64-apple-darwin" ;;
-            windows-amd64) target="x86_64-pc-windows-msvc" ;;
-            windows-arm64) target="aarch64-pc-windows-msvc" ;;
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"
@@ -128,10 +104,7 @@ jobs:
               esac
             fi
             cd proplet && cargo build --release --target "$target"
-            mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
-          else
-            cd proplet && cargo build --release
-            mv proplet/target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+            mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}
           fi
 
       - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,14 +83,19 @@ jobs:
       - name: Build
         run: |
           mkdir -p dist
-          rustup target add ${{ matrix.goarch }}-unknown-linux-gnu
+          case "${{ matrix.goarch }}" in
+            amd64) target="x86_64-unknown-linux-gnu" ;;
+            arm64) target="aarch64-unknown-linux-gnu" ;;
+            riscv64) target="riscv64gc-unknown-linux-gnu" ;;
+          esac
+          rustup target add "$target"
           if [ "${{ matrix.goarch }}" = "arm64" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           elif [ "${{ matrix.goarch }}" = "riscv64" ]; then
             export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
           fi
-          cd proplet && cargo build --release --target ${{ matrix.goarch }}-unknown-linux-gnu
-          mv target/${{ matrix.goarch }}-unknown-linux-gnu/release/proplet ../dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}
+          cd proplet && cargo build --release --target "$target"
+          mv target/$target/release/proplet ../dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,18 @@ on:
   push:
     branches:
       - main
+
     tags:
       - "v*"
+
   pull_request:
     branches:
       - main
-      - feat/ci
+
   workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,10 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Build
-        shell: bash
         run: |
           mkdir -p dist
-          ext=""
-          [ "${{ matrix.goos }}" = "windows" ] && ext=".exe"
           make ${{ matrix.service }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0
-          mv build/${{ matrix.service }} dist/${{ matrix.service }}-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+          mv build/${{ matrix.service }} dist/${{ matrix.service }}-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -58,14 +55,14 @@ jobs:
 
   proplet:
     name: proplet-${{ matrix.goos }}-${{ matrix.goarch }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux, goarch: amd64, runner: ubuntu-latest }
-          - { goos: linux, goarch: arm64, runner: ubuntu-latest }
-          - { goos: linux, goarch: riscv64, runner: ubuntu-latest }
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: linux, goarch: riscv64 }
 
     steps:
       - name: Checkout Code
@@ -75,37 +72,25 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cross-compilation toolchains
-        if: matrix.runner == 'ubuntu-latest' && matrix.goarch != 'amd64'
-        shell: bash
+        if: matrix.goarch != 'amd64'
         run: |
           sudo apt-get update
-          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
-            linux-arm64) sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;;
-            linux-riscv64) sudo apt-get install -y gcc-riscv64-linux-gnu libc6-dev-riscv64-cross ;;
+          case "${{ matrix.goarch }}" in
+            arm64) sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;;
+            riscv64) sudo apt-get install -y gcc-riscv64-linux-gnu libc6-dev-riscv64-cross ;;
           esac
 
       - name: Build
-        shell: bash
-        env:
-          target: ""
         run: |
           mkdir -p dist
-          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
-            linux-amd64) target="x86_64-unknown-linux-gnu" ;;
-            linux-arm64) target="aarch64-unknown-linux-gnu" ;;
-            linux-riscv64) target="riscv64gc-unknown-linux-gnu" ;;
-          esac
-          if [ -n "$target" ]; then
-            rustup target add "$target"
-            if [ "${{ matrix.goos }}" = "linux" ]; then
-              case "${{ matrix.goarch }}" in
-                arm64) export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc ;;
-                riscv64) export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc ;;
-              esac
-            fi
-            cd proplet && cargo build --release --target "$target"
-            mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}
+          rustup target add ${{ matrix.goarch }}-unknown-linux-gnu
+          if [ "${{ matrix.goarch }}" = "arm64" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          elif [ "${{ matrix.goarch }}" = "riscv64" ]; then
+            export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
           fi
+          cd proplet && cargo build --release --target ${{ matrix.goarch }}-unknown-linux-gnu
+          mv target/${{ matrix.goarch }}-unknown-linux-gnu/release/proplet ../dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,11 +150,11 @@ jobs:
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"
-            cargo build --release --target "$target" -p proplet
-            mv target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+            cd proplet && cargo build --release --target "$target"
+            mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
           else
-            cargo build --release -p proplet
-            mv target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+            cd proplet && cargo build --release
+            mv proplet/target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
           fi
 
       - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - feat/ci
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,32 +14,60 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.goos }}/${{ matrix.goarch }}
+    name: ${{ matrix.goos }}/${{ matrix.goarch }}/${{ matrix.service }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           # linux — amd64, arm64, riscv64 all supported out-of-the-box
-          - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: linux, goarch: riscv64 }
+          - { goos: linux, goarch: amd64, service: manager }
+          - { goos: linux, goarch: arm64, service: manager }
+          - { goos: linux, goarch: riscv64, service: manager }
+          - { goos: linux, goarch: amd64, service: cli }
+          - { goos: linux, goarch: arm64, service: cli }
+          - { goos: linux, goarch: riscv64, service: cli }
+          - { goos: linux, goarch: amd64, service: proxy }
+          - { goos: linux, goarch: arm64, service: proxy }
+          - { goos: linux, goarch: riscv64, service: proxy }
           # darwin (macOS) — only amd64 and arm64 (Apple Silicon)
-          - { goos: darwin, goarch: amd64 }
-          - { goos: darwin, goarch: arm64 }
+          - { goos: darwin, goarch: amd64, service: manager }
+          - { goos: darwin, goarch: arm64, service: manager }
+          - { goos: darwin, goarch: amd64, service: cli }
+          - { goos: darwin, goarch: arm64, service: cli }
+          - { goos: darwin, goarch: amd64, service: proxy }
+          - { goos: darwin, goarch: arm64, service: proxy }
           # windows — amd64 and arm64; riscv64 is not a valid windows target
-          - { goos: windows, goarch: amd64 }
-          - { goos: windows, goarch: arm64 }
+          - { goos: windows, goarch: amd64, service: manager }
+          - { goos: windows, goarch: arm64, service: manager }
+          - { goos: windows, goarch: amd64, service: cli }
+          - { goos: windows, goarch: arm64, service: cli }
+          - { goos: windows, goarch: amd64, service: proxy }
+          - { goos: windows, goarch: arm64, service: proxy }
           # freebsd — riscv64 added in Go 1.20
-          - { goos: freebsd, goarch: amd64 }
-          - { goos: freebsd, goarch: arm64 }
-          - { goos: freebsd, goarch: riscv64 }
+          - { goos: freebsd, goarch: amd64, service: manager }
+          - { goos: freebsd, goarch: arm64, service: manager }
+          - { goos: freebsd, goarch: riscv64, service: manager }
+          - { goos: freebsd, goarch: amd64, service: cli }
+          - { goos: freebsd, goarch: arm64, service: cli }
+          - { goos: freebsd, goarch: riscv64, service: cli }
+          - { goos: freebsd, goarch: amd64, service: proxy }
+          - { goos: freebsd, goarch: arm64, service: proxy }
+          - { goos: freebsd, goarch: riscv64, service: proxy }
           # netbsd — no riscv64 port
-          - { goos: netbsd, goarch: amd64 }
-          - { goos: netbsd, goarch: arm64 }
+          - { goos: netbsd, goarch: amd64, service: manager }
+          - { goos: netbsd, goarch: arm64, service: manager }
+          - { goos: netbsd, goarch: amd64, service: cli }
+          - { goos: netbsd, goarch: arm64, service: cli }
+          - { goos: netbsd, goarch: amd64, service: proxy }
+          - { goos: netbsd, goarch: arm64, service: proxy }
           # openbsd — no riscv64 port
-          - { goos: openbsd, goarch: amd64 }
-          - { goos: openbsd, goarch: arm64 }
+          - { goos: openbsd, goarch: amd64, service: manager }
+          - { goos: openbsd, goarch: arm64, service: manager }
+          - { goos: openbsd, goarch: amd64, service: cli }
+          - { goos: openbsd, goarch: arm64, service: cli }
+          - { goos: openbsd, goarch: amd64, service: proxy }
+          - { goos: openbsd, goarch: arm64, service: proxy }
 
     steps:
       - name: Checkout Code
@@ -56,15 +84,13 @@ jobs:
           mkdir -p dist
           ext=""
           [ "${{ matrix.goos }}" = "windows" ] && ext=".exe"
-          for svc in manager cli proxy; do
-            make $svc GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0
-            mv build/$svc dist/${svc}-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
-          done
+          make ${{ matrix.service }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0
+          mv build/${{ matrix.service }} dist/${{ matrix.service }}-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: ${{ matrix.service }}-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/
           retention-days: 7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,22 +81,22 @@ jobs:
 
   proplet:
     name: proplet-${{ matrix.goos }}-${{ matrix.goarch }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: linux, goarch: riscv64 }
-          - { goos: darwin, goarch: amd64 }
-          - { goos: darwin, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
-          - { goos: windows, goarch: arm64 }
-          - { goos: freebsd, goarch: amd64 }
-          - { goos: freebsd, goarch: arm64 }
-          - { goos: netbsd, goarch: amd64 }
-          - { goos: openbsd, goarch: amd64 }
+          - { goos: linux, goarch: amd64, runner: ubuntu-latest }
+          - { goos: linux, goarch: arm64, runner: ubuntu-latest }
+          - { goos: linux, goarch: riscv64, runner: ubuntu-latest }
+          - { goos: darwin, goarch: amd64, runner: macos-latest }
+          - { goos: darwin, goarch: arm64, runner: macos-latest }
+          - { goos: windows, goarch: amd64, runner: ubuntu-latest }
+          - { goos: windows, goarch: arm64, runner: ubuntu-latest }
+          - { goos: freebsd, goarch: amd64, runner: ubuntu-latest }
+          - { goos: freebsd, goarch: arm64, runner: ubuntu-latest }
+          - { goos: netbsd, goarch: amd64, runner: ubuntu-latest }
+          - { goos: openbsd, goarch: amd64, runner: ubuntu-latest }
 
     steps:
       - name: Checkout Code
@@ -106,13 +106,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cross-compilation toolchains
-        if: matrix.goarch != 'amd64'
+        if: matrix.runner == 'ubuntu-latest' && matrix.goarch != 'amd64'
         run: |
           sudo apt-get update
           case "${{ matrix.goos }}-${{ matrix.goarch }}" in
             linux-arm64) sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;;
             linux-riscv64) sudo apt-get install -y gcc-riscv64-linux-gnu libc6-dev-riscv64-cross ;;
-            freebsd-*) sudo apt-get install -y gcc-cross libclang-rt ;;  # FreeBSD targets need cross compilers
+            freebsd-*) sudo apt-get install -y gcc-cross libclang-rt ;;
           esac
 
       - name: Build
@@ -139,8 +139,12 @@ jobs:
           esac
           if [ -n "$target" ]; then
             rustup target add "$target"
-            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-            export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
+            if [ "${{ matrix.goos }}" = "linux" ]; then
+              case "${{ matrix.goarch }}" in
+                arm64) export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc ;;
+                riscv64) export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc ;;
+              esac
+            fi
             cd proplet && cargo build --release --target "$target"
             mv proplet/target/$target/release/proplet dist/proplet-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,88 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # linux — amd64, arm64, riscv64 all supported out-of-the-box
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: linux, goarch: riscv64 }
+          # darwin (macOS) — only amd64 and arm64 (Apple Silicon)
+          - { goos: darwin, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
+          # windows — amd64 and arm64; riscv64 is not a valid windows target
+          - { goos: windows, goarch: amd64 }
+          - { goos: windows, goarch: arm64 }
+          # freebsd — riscv64 added in Go 1.20
+          - { goos: freebsd, goarch: amd64 }
+          - { goos: freebsd, goarch: arm64 }
+          - { goos: freebsd, goarch: riscv64 }
+          # netbsd — no riscv64 port
+          - { goos: netbsd, goarch: amd64 }
+          - { goos: netbsd, goarch: arm64 }
+          # openbsd — no riscv64 port
+          - { goos: openbsd, goarch: amd64 }
+          - { goos: openbsd, goarch: arm64 }
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.8
+          cache-dependency-path: go.sum
+
+      - name: Build
+        run: |
+          mkdir -p dist
+          ext=""
+          [ "${{ matrix.goos }}" = "windows" ] && ext=".exe"
+          for svc in manager cli proxy; do
+            make $svc GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0
+            mv build/$svc dist/${svc}-${{ matrix.goos }}-${{ matrix.goarch }}${ext}
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
+          retention-days: 7
+
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
           - { goos: linux, goarch: riscv64, runner: ubuntu-latest }
           - { goos: darwin, goarch: amd64, runner: macos-latest }
           - { goos: darwin, goarch: arm64, runner: macos-latest }
-          - { goos: windows, goarch: amd64, runner: ubuntu-latest }
-          - { goos: windows, goarch: arm64, runner: ubuntu-latest }
+          - { goos: windows, goarch: amd64, runner: windows-latest }
+          - { goos: windows, goarch: arm64, runner: windows-latest }
           - { goos: freebsd, goarch: amd64, runner: ubuntu-latest }
           - { goos: freebsd, goarch: arm64, runner: ubuntu-latest }
           - { goos: netbsd, goarch: amd64, runner: ubuntu-latest }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - main
+      - feat/ci
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/absmach/propeller
+  IMAGE_PREFIX: ghcr.io/rodneyosodo/propeller
 
 jobs:
   docker-go:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,6 +156,8 @@ jobs:
           # OpenVINO backend is x86-only
           platforms: linux/amd64
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}/proplet:wasi-nn
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/proplet-wasi-nn:latest
+            ${{ env.IMAGE_PREFIX }}/proplet-wasi-nn:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,12 +4,73 @@ on:
   push:
     branches:
       - main
-
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/absmach/propeller
+
 jobs:
-  build-and-push:
-    name: Build and Push
+  docker-go:
+    name: Docker Go / ${{ matrix.svc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        svc: [manager, cli, proxy]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute build metadata
+        id: meta
+        run: |
+          echo "version=$(git describe --abbrev=0 --tags 2>/dev/null || echo 'v0.0.0')" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "time=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          # Docker images only make sense on Linux; riscv64 support in the
+          # alpine builder image and multi-arch manifests is available.
+          platforms: linux/amd64,linux/arm64,linux/riscv64
+          push: true
+          build-args: |
+            SVC=${{ matrix.svc }}
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ steps.meta.outputs.commit }}
+            TIME=${{ steps.meta.outputs.time }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.svc }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.svc }}:${{ steps.meta.outputs.commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-proplet:
+    name: Docker proplet
     runs-on: ubuntu-latest
 
     permissions:
@@ -22,21 +83,78 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Build
+      - name: Compute build metadata
+        id: meta
+        run: |
+          echo "version=$(git describe --abbrev=0 --tags 2>/dev/null || echo 'v0.0.0')" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "time=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker images
-        run: |
-          make latest -j $(nproc)
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.proplet
+          # The builder stage uses FROM --platform=$BUILDPLATFORM so Rust
+          # cross-compiles on the host (amd64) rather than running under QEMU.
+          # wasmtime releases provide amd64 and arm64 Linux binaries.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ steps.meta.outputs.commit }}
+            TIME=${{ steps.meta.outputs.time }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/proplet:latest
+            ${{ env.IMAGE_PREFIX }}/proplet:${{ steps.meta.outputs.commit }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build and push proplet wasi-nn image
-        run: |
-          make docker_proplet_wasinn
-          make push_proplet_wasinn
+  docker-proplet-wasinn:
+    name: Docker proplet (wasi-nn)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.proplet-wasinn
+          # OpenVINO backend is x86-only
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/proplet:wasi-nn
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - feat/ci
+
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/rodneyosodo/propeller
+  IMAGE_PREFIX: ghcr.io/absmach/propeller
 
 jobs:
   docker-go:

--- a/docker/.env
+++ b/docker/.env
@@ -615,6 +615,7 @@ PROXY_REGISTRY_PASSWORD=""
 PROXY_REGISTRY_URL="docker.io"
 PROPLET_CONFIG_FILE="config.toml"
 PROPLET_CONFIG_SECTION="proplet"
+PROPLET_IMAGE="ghcr.io/absmach/propeller/proplet"
 PROPLET_IMAGE_TAG="latest"
 
 # ----------------------------------------------------------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,11 @@
 FROM golang:1.26-alpine3.23 AS builder
 ARG SVC
-ARG GOARCH
+# TARGETARCH / TARGETVARIANT are set automatically by docker buildx.
+# GOARCH / GOARM can still be passed explicitly via --build-arg to keep
+# backwards-compatibility with the `make dockers` Makefile targets.
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG GOARCH=${TARGETARCH}
 ARG GOARM
 ARG VERSION
 ARG COMMIT
@@ -10,8 +15,9 @@ WORKDIR /go/src/github.com/absmach/propeller
 COPY . .
 RUN apk update \
     && apk add make upx \
-    && make $SVC \
-    && upx --best build/$SVC \
+    && _goarm="${GOARM:-${TARGETVARIANT#v}}" \
+    && make $SVC GOARCH=${GOARCH} ${_goarm:+GOARM=${_goarm}} \
+    && (upx --best build/$SVC 2>/dev/null || true) \
     && mv build/$SVC /exe
 
 FROM scratch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,9 @@ ARG TIME
 WORKDIR /go/src/github.com/absmach/propeller
 COPY . .
 RUN apk update \
-    && apk add make upx \
+    && apk add make \
     && _goarm="${GOARM:-${TARGETVARIANT#v}}" \
     && make $SVC GOARCH=${GOARCH} ${_goarm:+GOARM=${_goarm}} \
-    && (upx --best build/$SVC 2>/dev/null || true) \
     && mv build/$SVC /exe
 
 FROM scratch

--- a/docker/Dockerfile.proplet
+++ b/docker/Dockerfile.proplet
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libclang-dev \
         gcc-aarch64-linux-gnu \
         libc6-dev-arm64-cross \
+        gcc-riscv64-linux-gnu \
+        libc6-dev-riscv64-cross \
     && case "${TARGETARCH}" in \
         amd64) \
             rustup target add x86_64-unknown-linux-gnu && \
@@ -30,6 +32,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
             CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
             cargo build --release --target aarch64-unknown-linux-gnu && \
             cp target/aarch64-unknown-linux-gnu/release/proplet /proplet ;; \
+        riscv64) \
+            rustup target add riscv64gc-unknown-linux-gnu && \
+            CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \
+            cargo build --release --target riscv64gc-unknown-linux-gnu && \
+            cp target/riscv64gc-unknown-linux-gnu/release/proplet /proplet ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac
 

--- a/docker/Dockerfile.proplet
+++ b/docker/Dockerfile.proplet
@@ -41,6 +41,9 @@ LABEL org.opencontainers.image.title="Propeller Proplet (Rust)"
 LABEL org.opencontainers.image.description="Propeller edge runtime for WebAssembly modules"
 
 ARG WASMTIME_VERSION=42.0.1
+ARG WASMTIME_SHA256_AMD64=dd5253f3cb521bb094f9951c3d2c45c746b31e5723b07ce56f162ec9bab44d59
+ARG WASMTIME_SHA256_ARM64=fa9b7e09f49f75c17acf2c018a4286cdbeffb4c1f3ee9e72c48b6a42c1deceda
+ARG WASMTIME_SHA256_RISCV64=04fd303b53315650a6cb7230d5a606c4d72187bee439a7ba269c5b2dade8712a
 ARG TARGETARCH
 
 # Map Docker's TARGETARCH to the architecture label used in wasmtime release tarballs.
@@ -50,15 +53,17 @@ RUN apt-get update && \
         wget \
         xz-utils && \
     case "${TARGETARCH}" in \
-        amd64)   WASMTIME_ARCH="x86_64" ;; \
-        arm64)   WASMTIME_ARCH="aarch64" ;; \
-        riscv64) WASMTIME_ARCH="riscv64gc" ;; \
+        amd64)   WASMTIME_ARCH="x86_64";    EXPECTED_SHA256="${WASMTIME_SHA256_AMD64}" ;; \
+        arm64)   WASMTIME_ARCH="aarch64";   EXPECTED_SHA256="${WASMTIME_SHA256_ARM64}" ;; \
+        riscv64) WASMTIME_ARCH="riscv64gc"; EXPECTED_SHA256="${WASMTIME_SHA256_RISCV64}" ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    wget -q "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" && \
-    tar -xf "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" && \
+    TARBALL="wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" && \
+    wget -q "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${TARBALL}" && \
+    echo "${EXPECTED_SHA256}  ${TARBALL}" | sha256sum -c - || { rm -f "${TARBALL}"; exit 1; } && \
+    tar -xf "${TARBALL}" && \
     mv "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux/wasmtime" /usr/local/bin/ && \
-    rm -rf "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux"* && \
+    rm -rf "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux" "${TARBALL}" && \
     apt-get remove -y wget xz-utils && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/docker/Dockerfile.proplet
+++ b/docker/Dockerfile.proplet
@@ -15,7 +15,6 @@ WORKDIR /build
 COPY proplet/ ./
 
 # Install cross-compilation toolchains and build for the target architecture.
-# upx is applied where supported (amd64 / arm64); it silently skips others.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         clang \
         libclang-dev \

--- a/docker/Dockerfile.proplet
+++ b/docker/Dockerfile.proplet
@@ -1,17 +1,40 @@
-FROM rust:1.94.0 AS builder
+# syntax=docker/dockerfile:1
+
+# Use the build-machine's platform for the builder stage so that Rust
+# cross-compiles natively instead of running the entire cargo build under
+# QEMU emulation (which would take hours for arm64).
+FROM --platform=$BUILDPLATFORM rust:1.94.0 AS builder
 
 ARG VERSION
 ARG COMMIT
 ARG TIME
+ARG TARGETARCH
 
 WORKDIR /build
 
-RUN apt update && apt install -y clang libclang-dev upx
-
 COPY proplet/ ./
 
-RUN cargo build --release && \
-    upx --best target/release/proplet
+# Install cross-compilation toolchains and build for the target architecture.
+# upx is applied where supported (amd64 / arm64); it silently skips others.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        clang \
+        libclang-dev \
+        upx \
+        gcc-aarch64-linux-gnu \
+    && case "${TARGETARCH}" in \
+        amd64) \
+            rustup target add x86_64-unknown-linux-gnu && \
+            cargo build --release --target x86_64-unknown-linux-gnu && \
+            (upx --best target/x86_64-unknown-linux-gnu/release/proplet 2>/dev/null || true) && \
+            cp target/x86_64-unknown-linux-gnu/release/proplet /proplet ;; \
+        arm64) \
+            rustup target add aarch64-unknown-linux-gnu && \
+            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+            cargo build --release --target aarch64-unknown-linux-gnu && \
+            (upx --best target/aarch64-unknown-linux-gnu/release/proplet 2>/dev/null || true) && \
+            cp target/aarch64-unknown-linux-gnu/release/proplet /proplet ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac
 
 FROM ubuntu:25.10
 
@@ -21,16 +44,24 @@ LABEL org.opencontainers.image.title="Propeller Proplet (Rust)"
 LABEL org.opencontainers.image.description="Propeller edge runtime for WebAssembly modules"
 
 ARG WASMTIME_VERSION=42.0.1
+ARG TARGETARCH
 
+# Map Docker's TARGETARCH to the architecture label used in wasmtime release tarballs.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
         xz-utils && \
-    wget -q https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    tar -xf wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    mv wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime /usr/local/bin/ && \
-    rm -rf wasmtime-v${WASMTIME_VERSION}-x86_64-linux* && \
+    case "${TARGETARCH}" in \
+        amd64)   WASMTIME_ARCH="x86_64" ;; \
+        arm64)   WASMTIME_ARCH="aarch64" ;; \
+        riscv64) WASMTIME_ARCH="riscv64gc" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    wget -q "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" && \
+    tar -xf "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" && \
+    mv "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux/wasmtime" /usr/local/bin/ && \
+    rm -rf "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux"* && \
     apt-get remove -y wget xz-utils && \
     apt-get autoremove -y && \
     apt-get clean && \
@@ -39,7 +70,7 @@ RUN apt-get update && \
 RUN groupadd -r proplet && \
     useradd -r -g proplet -s /bin/false proplet
 
-COPY --from=builder /build/target/release/proplet /usr/local/bin/proplet
+COPY --from=builder /proplet /usr/local/bin/proplet
 
 RUN chown proplet:proplet /usr/local/bin/proplet && \
     chmod +x /usr/local/bin/proplet && \

--- a/docker/Dockerfile.proplet
+++ b/docker/Dockerfile.proplet
@@ -19,19 +19,17 @@ COPY proplet/ ./
 RUN apt-get update && apt-get install -y --no-install-recommends \
         clang \
         libclang-dev \
-        upx \
         gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross \
     && case "${TARGETARCH}" in \
         amd64) \
             rustup target add x86_64-unknown-linux-gnu && \
             cargo build --release --target x86_64-unknown-linux-gnu && \
-            (upx --best target/x86_64-unknown-linux-gnu/release/proplet 2>/dev/null || true) && \
             cp target/x86_64-unknown-linux-gnu/release/proplet /proplet ;; \
         arm64) \
             rustup target add aarch64-unknown-linux-gnu && \
             CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
             cargo build --release --target aarch64-unknown-linux-gnu && \
-            (upx --best target/aarch64-unknown-linux-gnu/release/proplet 2>/dev/null || true) && \
             cp target/aarch64-unknown-linux-gnu/release/proplet /proplet ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac

--- a/docker/Dockerfile.proplet-wasinn
+++ b/docker/Dockerfile.proplet-wasinn
@@ -6,12 +6,11 @@ ARG TIME
 
 WORKDIR /build
 
-RUN apt update && apt install -y clang libclang-dev upx
+RUN apt update && apt install -y clang libclang-dev
 
 COPY proplet/ ./
 
-RUN cargo build --release && \
-    upx --best target/release/proplet
+RUN cargo build --release
 
 FROM ubuntu:25.10
 

--- a/docker/Dockerfile.proplet-wasinn
+++ b/docker/Dockerfile.proplet-wasinn
@@ -20,6 +20,7 @@ LABEL org.opencontainers.image.title="Propeller Proplet with wasi-nn"
 LABEL org.opencontainers.image.description="Propeller edge runtime with wasi-nn/OpenVINO support"
 
 ARG WASMTIME_VERSION=42.0.1
+ARG WASMTIME_SHA256=dd5253f3cb521bb094f9951c3d2c45c746b31e5723b07ce56f162ec9bab44d59
 ARG OPENVINO_VERSION=2025.4.0.20398.8fdad55727d
 
 RUN apt-get update && \
@@ -29,10 +30,12 @@ RUN apt-get update && \
         curl \
         xz-utils \
         libtbb12 && \
-    wget -q https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    tar -xf wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    mv wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime /usr/local/bin/ && \
-    rm -rf wasmtime-v${WASMTIME_VERSION}-x86_64-linux* && \
+    TARBALL="wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz" && \
+    wget -q "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${TARBALL}" && \
+    echo "${WASMTIME_SHA256}  ${TARBALL}" | sha256sum -c - || { rm -f "${TARBALL}"; exit 1; } && \
+    tar -xf "${TARBALL}" && \
+    mv "wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime" /usr/local/bin/ && \
+    rm -rf "wasmtime-v${WASMTIME_VERSION}-x86_64-linux" "${TARBALL}" && \
     mkdir -p /opt/intel && \
     cd /tmp && \
     curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.4/linux/openvino_toolkit_ubuntu24_${OPENVINO_VERSION}_x86_64.tgz --output openvino.tgz && \

--- a/docker/Dockerfile.proplet.dev
+++ b/docker/Dockerfile.proplet.dev
@@ -6,16 +6,19 @@ LABEL org.opencontainers.image.title="Propeller Proplet Dev (Rust)"
 LABEL org.opencontainers.image.description="Development image for Propeller edge runtime"
 
 ARG WASMTIME_VERSION=42.0.1
+ARG WASMTIME_SHA256=dd5253f3cb521bb094f9951c3d2c45c746b31e5723b07ce56f162ec9bab44d59
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
         xz-utils && \
-    wget -q https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    tar -xf wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz && \
-    mv wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime /usr/local/bin/ && \
-    rm -rf wasmtime-v${WASMTIME_VERSION}-x86_64-linux* && \
+    TARBALL="wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz" && \
+    wget -q "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${TARBALL}" && \
+    echo "${WASMTIME_SHA256}  ${TARBALL}" | sha256sum -c - || { rm -f "${TARBALL}"; exit 1; } && \
+    tar -xf "${TARBALL}" && \
+    mv "wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime" /usr/local/bin/ && \
+    rm -rf "wasmtime-v${WASMTIME_VERSION}-x86_64-linux" "${TARBALL}" && \
     apt-get remove -y wget xz-utils && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/docker/compose.propeller.yaml
+++ b/docker/compose.propeller.yaml
@@ -56,15 +56,16 @@ services:
       - supermq-base-net
 
   # Proplet - WebAssembly edge runtime
-  # Available image tags:
-  #   - latest   (base, lightweight)
-  #   - wasi-nn  (with wasi-nn/OpenVINO, x86_64 only)
+  # Available images:
+  #   - ghcr.io/absmach/propeller/proplet:latest         (base, lightweight)
+  #   - ghcr.io/absmach/propeller/proplet-wasi-nn:latest (with wasi-nn/OpenVINO, x86_64 only)
   #
   # For wasi-nn support, set in .env:
-  #   1. PROPLET_IMAGE_TAG=wasi-nn
-  #   2. PROPLET_EXTERNAL_WASM_RUNTIME=wasmtime
+  #   1. PROPLET_IMAGE=ghcr.io/absmach/propeller/proplet-wasi-nn
+  #   2. PROPLET_IMAGE_TAG=latest
+  #   3. PROPLET_EXTERNAL_WASM_RUNTIME=wasmtime
   proplet:
-    image: ghcr.io/absmach/propeller/proplet:${PROPLET_IMAGE_TAG}
+    image: ${PROPLET_IMAGE}:${PROPLET_IMAGE_TAG}
     container_name: propeller-proplet
     restart: on-failure
     healthcheck:

--- a/proplet/Cargo.toml
+++ b/proplet/Cargo.toml
@@ -27,7 +27,7 @@ sysinfo = "0.38.4"
 chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 
 # TEE & Encryption Support (default feature)
 attestation-agent = { git = "https://github.com/rodneyosodo/guest-components", branch = "enable-wasm-workloads", default-features = false, features = ["rust-crypto", "kbs"] }

--- a/proplet/Cargo.toml
+++ b/proplet/Cargo.toml
@@ -27,7 +27,7 @@ sysinfo = "0.38.4"
 chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json"] }
 
 # TEE & Encryption Support (default feature)
 attestation-agent = { git = "https://github.com/rodneyosodo/guest-components", branch = "enable-wasm-workloads", default-features = false, features = ["rust-crypto", "kbs"] }


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?


## Did you document any new/modified features?


### Notes

Signed-off-by: Rodney Osodo <socials@rodneyosodo.com>

## Summary by Sourcery

Introduce multi-architecture build and release workflows and extend Docker image publishing for multiple services and platforms.

Build:
- Add a matrix-based GitHub Actions build workflow to compile and archive binaries for multiple GOOS/GOARCH combinations and publish tagged releases to GitHub.
- Update CD workflow to build and push multi-arch Docker images for Go services and proplet variants using Buildx and QEMU, tagging images with latest and commit-based tags.
- Adjust Dockerfile to better support Buildx cross-compilation by wiring TARGETARCH/TARGETVARIANT into Go build args and making binary compression optional.
- Tidy Dependabot configuration formatting without changing behavior.

CI:
- Enable CI workflows on the feat/ci branch alongside main and support manual workflow dispatch for build and CD jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed Dependabot configuration.

* **New Features**
  * Added automated multi-platform build and release pipeline producing and attaching architecture-specific binaries to releases.
  * Added multi-architecture Docker image publishing and per-service image artifacts (amd64, arm64, riscv64).
  * Expanded CI triggers and cross-compilation support for broader platform coverage.
  * HTTP client now enables Rustls TLS support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->